### PR TITLE
Update .gitignore to include jekyll-cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 */_cache/
 */_site/**
 */_site/*
+*/jekyll-cache/*


### PR DESCRIPTION
- Added jekyll-cache to the .gitignore file to prevent caching files from being tracked.