### PR TITLE
Enhance GitHub Actions workflow to handle Formspree ID conditionally

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -34,7 +34,12 @@ jobs:
         run: |
           sed -i "s|domain:.*|domain: \"${{ vars.FULL_DOMAIN }}\"|" ./src/_config.yml
 
-          sed -i "s|formspree_id:.*|formspree_id: \"${{ secrets.FORMSPREE_ID }}\"|" ./src/_config.yml
+          # Handle formspree_id whether it's empty or has a value
+          if [ -n "${{ secrets.FORMSPREE_ID }}" ]; then
+            sed -i "s|formspree_id:.*|formspree_id: \"${{ secrets.FORMSPREE_ID }}\"|" ./src/_config.yml
+          else
+            echo "Warning: FORMSPREE_ID secret is not set"
+          fi
 
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1


### PR DESCRIPTION
- Updated the Jekyll deployment workflow to check if the FORMSPREE_ID secret is set before updating the configuration. Added a warning message for unset secrets to improve error handling.